### PR TITLE
Seraphim Rift

### DIFF
--- a/BlackOpsUnleashed/hook/units/DSLK004/DSLK004_unit.bp
+++ b/BlackOpsUnleashed/hook/units/DSLK004/DSLK004_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "dslk004",    -- Seraphim T3 AA Lightning Tank
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSA0202/XSA0202_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSA0202/XSA0202_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsa0202",    -- Seraphim Fighter Bomber
-    Categories = {
-        'BUILTBYRIFTGATE'
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSA0203/XSA0203_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSA0203/XSA0203_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsa0203",    -- Seraphim Gunship
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSA0204/XSA0204_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSA0204/XSA0204_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsa0204",    -- Seraphim Torpedo Bomber
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0111/XSL0111_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0111/XSL0111_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0111",    -- Seraphim T2 Mobile Missile Launcher
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0202/XSL0202_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0202/XSL0202_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0202",    -- Seraphim T2 Assault Bot
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0203/XSL0203_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0203/XSL0203_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0203",    -- Seraphim T2 Hover Tank
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0205/XSL0205_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0205/XSL0205_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0205",    -- Seraphim T2 Hover Flak
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0303/XSL0303_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0303/XSL0303_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0303",    -- Seraphim T3 Siege Tank
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0304/XSL0304_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0304/XSL0304_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0304",    -- Seraphim T3 Mobile Heavy Artillery
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0305/XSL0305_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0305/XSL0305_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0305",    -- Seraphim T3 Sniper Bot
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/hook/units/XSL0307/XSL0307_unit.bp
+++ b/BlackOpsUnleashed/hook/units/XSL0307/XSL0307_unit.bp
@@ -1,7 +1,0 @@
-UnitBlueprint {
-    Merge = true,
-    BlueprintId = "xsl0307",    -- Seraphim T3 Mobile Shield Generator
-    Categories = {
-        'BUILTBYRIFTGATE',
-    },
-}

--- a/BlackOpsUnleashed/units/BSB0002/BSB0002_unit.bp
+++ b/BlackOpsUnleashed/units/BSB0002/BSB0002_unit.bp
@@ -58,7 +58,17 @@ UnitBlueprint {
         BuildTime = 1,
         BuildRate = 300,
         BuildableCategory = {
-            'BUILTBYRIFTGATE SERAPHIM',
+            'dslk004', -- Seraphim T3 AA Lightning Tank
+            'xsa0202', -- Seraphim Fighter Bomber
+            'xsa0203', -- Seraphim Gunship
+            'xsa0204', -- Seraphim Torpedo Bomber
+            'xsl0111', -- Seraphim T2 Mobile Missile Launcher
+            'xsl0202', -- Seraphim T2 Assault Bot
+            'xsl0205', -- Seraphim T2 Hover Flak
+            'xsl0303', -- Seraphim T3 Siege Tank
+            'xsl0304', -- Seraphim T3 Mobile Heavy Artillery
+            'xsl0305', -- Seraphim T3 Sniper Bot
+            'xsl0307', -- Seraphim T3 Mobile Shield Generator
         },
     },
     General = {

--- a/BlackOpsUnleashed/units/BSB2402/BSB2402_unit.bp
+++ b/BlackOpsUnleashed/units/BSB2402/BSB2402_unit.bp
@@ -95,7 +95,17 @@ UnitBlueprint {
         BuildTime = 90000,
         BuildRate = 300,
         BuildableCategory = {
-            'BUILTBYARCH',
+            'dslk004', -- Seraphim T3 AA Lightning Tank
+            'xsa0202', -- Seraphim Fighter Bomber
+            'xsa0203', -- Seraphim Gunship
+            'xsa0204', -- Seraphim Torpedo Bomber
+            'xsl0111', -- Seraphim T2 Mobile Missile Launcher
+            'xsl0202', -- Seraphim T2 Assault Bot
+            'xsl0205', -- Seraphim T2 Hover Flak
+            'xsl0303', -- Seraphim T3 Siege Tank
+            'xsl0304', -- Seraphim T3 Mobile Heavy Artillery
+            'xsl0305', -- Seraphim T3 Sniper Bot
+            'xsl0307', -- Seraphim T3 Mobile Shield Generator
         },
         RebuildBonusIds = {
             'bsb2402',


### PR DESCRIPTION
Added BuildableCategory to Main AND Sub(Drone) Factory.

We allow the ARCH to build units over the BuildableCategory, So we dont need merged blueprints with the `BUILTBYRIFTGATE` Category.
