### PR TITLE
Assist Mex to Build "TECH3" Mass Storages

### DIFF
--- a/BlackOpsUnleashed/hook/lua/SimCallbacks.lua
+++ b/BlackOpsUnleashed/hook/lua/SimCallbacks.lua
@@ -1,0 +1,23 @@
+-- overwrite the original function. Destructive hook !
+Callbacks.CapMex = function(data, units)
+    local units = EntityCategoryFilterDown(categories.ENGINEER, SecureUnits(units))
+    if not units[1] then return end
+    local mex = GetEntityById(data.target)
+    if not mex or not EntityCategoryContains(categories.MASSEXTRACTION * categories.STRUCTURE, mex) then return end
+    local pos = mex:GetPosition()
+    local msid
+    local LetterArray = { ["Aeon"] = "ua", ["UEF"] = "ue", ["Cybran"] = "ur", ["Seraphim"] = "xs" }
+    local BOLetterArray = { ["Aeon"] = "ba", ["UEF"] = "be", ["Cybran"] = "br", ["Seraphim"] = "bs" }
+    for _, u in units do
+        local FactionName = u:GetBlueprint().General.FactionName
+        if u:CanBuild(BOLetterArray[FactionName]..'b1106') then
+            msid = BOLetterArray[u:GetBlueprint().General.FactionName]..'b1106'
+        else
+            msid = LetterArray[u:GetBlueprint().General.FactionName]..'b1106'
+        end
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z-2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x+2, pos.y, pos.z), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z+2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x-2, pos.y, pos.z), msid, {})
+    end
+end

--- a/BlackOpsUnleashed/hook/lua/SimCallbacks.lua
+++ b/BlackOpsUnleashed/hook/lua/SimCallbacks.lua
@@ -11,9 +11,9 @@ Callbacks.CapMex = function(data, units)
     for _, u in units do
         local FactionName = u:GetBlueprint().General.FactionName
         if u:CanBuild(BOLetterArray[FactionName]..'b1106') then
-            msid = BOLetterArray[u:GetBlueprint().General.FactionName]..'b1106'
+            msid = BOLetterArray[FactionName]..'b1106'
         else
-            msid = LetterArray[u:GetBlueprint().General.FactionName]..'b1106'
+            msid = LetterArray[FactionName]..'b1106'
         end
         IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z-2), msid, {})
         IssueBuildMobile({u}, Vector(pos.x+2, pos.y, pos.z), msid, {})


### PR DESCRIPTION
adding a new file SimCallbacks.lua and hooking function Callbacks.CapMex.

if you have Black Ops installed, and you assist a T2 or T3 Mex with an
Tech3 engineer, then it will build the Black ops Tech3 mass storage
around the mex.

Works also if you mix Tech1 and Tech3 units. Also with techs from
different factions.
